### PR TITLE
PS1 중복 코드 제거

### DIFF
--- a/init_scripts.sh
+++ b/init_scripts.sh
@@ -29,7 +29,7 @@ echo "alias dk='docker'" >> ${PROFILE}
 source $PROFILE
 
 BASHRC='/etc/bashrc'
-echo 'export PS1="\[\e[1;34m\]DEV\[\e[m\]\[\e[1;34m\]-\[\e[m\][\h:\$(pwd)] " ' >> ${BASHRC}
+echo 'export PS1="\[\e[1;34m\]DEV-\[\e[m\][\h:\w] " ' >> ${BASHRC}
 source $BASHRC
 
 VIMRC='/etc/vimrc'


### PR DESCRIPTION
- DEV- 로 표시되는 부분에 color code가 중복되어 제거
- pwd 명령어 대신 escape sequence를 사용하여 home directory는 ~로 표시되도록 변경